### PR TITLE
Add TLS verification option for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ git+https://github.com/prakhara56/FlexiStore.git@main#egg=flexistore
 from flexistore.azure import AzureStorageManager
 
 # Initialize with your connection string and container
-mgr = AzureStorageManager(conn_str="<AZURE_CONN_STRING>", container="my-container")
+mgr = AzureStorageManager(
+    conn_str="<AZURE_CONN_STRING>",
+    container="my-container",
+    verify_ssl=True,  # set to False to skip TLS verification
+)
 
 # Upload a local file
 mgr.upload_file("./data/report.csv", "backups/report.csv")
@@ -68,6 +72,7 @@ Follow the interactive prompts to upload, list, download, or delete objects.
 ### `AzureStorageManager`
 
 Concrete implementation using Azure Blob Storage with built-in error handling.
+`verify_ssl` (bool) controls TLS certificate verification when connecting.
 
 ### `AWSStorageManager`
 

--- a/flexistore/azure.py
+++ b/flexistore/azure.py
@@ -6,13 +6,13 @@ from typing import List
 from .manager import StorageManager
 
 class AzureStorageManager(StorageManager):
-    def __init__(self, conn_str: str, container: str):
+    def __init__(self, conn_str: str, container: str, verify_ssl: bool = True):
         if not BlobServiceClient:
             raise ImportError("azure-storage-blob is required")
         try:
             client = BlobServiceClient.from_connection_string(
                 conn_str,
-                transport=RequestsTransport(connection_verify=False)
+                transport=RequestsTransport(connection_verify=verify_ssl)
             )
             self.container: ContainerClient = client.get_container_client(container)
             print(f"Connected to Azure container '{container}' successfully.")


### PR DESCRIPTION
## Summary
- allow disabling TLS verification when using Azure storage
- document the `verify_ssl` flag

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876ae2e4ef08326bc70d3c465ab417f